### PR TITLE
don't do html_entity_decoding already in editor (+ TinyMCE added)

### DIFF
--- a/plugins/default/forms/HtmlSidebar/save.php
+++ b/plugins/default/forms/HtmlSidebar/save.php
@@ -11,7 +11,7 @@
  ?>
  <div>
 	<label><?php echo ossn_print('htmlsidebar:entertext'); ?></label>
- 	<textarea name="html"><?php $component = new OssnComponents; $settings = $component->getSettings('HtmlSidebar'); echo html_sidebar_output($settings->free_html); ?></textarea>
+ 	<textarea class="ossn-editor" name="html"><?php $component = new OssnComponents; $settings = $component->getSettings('HtmlSidebar'); echo $settings->free_html;?></textarea>
  </div>
  <div>
  	<input type="submit" value="<?php echo ossn_print('button:save'); ?>" class="btn btn-primary"/>


### PR DESCRIPTION
otherwise we might change some formerly saved code like "\&lt;" unintentionally to "<"